### PR TITLE
Replace the legacy querystring API by the URLSearchParams API

### DIFF
--- a/src/services/binance-api.js
+++ b/src/services/binance-api.js
@@ -1,6 +1,5 @@
 import fetch from "node-fetch";
 import crypto from "crypto";
-import querystring from "querystring";
 
 export class BinanceAPI {
 	/**
@@ -26,7 +25,7 @@ export class BinanceAPI {
 	createSignature(params) {
 		return crypto
 			.createHmac("sha256", this.secret)
-			.update(querystring.stringify(params))
+			.update(new URLSearchParams(params).toString())
 			.digest("hex");
 	}
 
@@ -42,7 +41,7 @@ export class BinanceAPI {
 
 		params.signature = this.createSignature(params);
 
-		const url = `${this.apiUrl}/api/v3/account?${querystring.stringify(params)}`;
+		const url = `${this.apiUrl}/api/v3/account?${new URLSearchParams(params).toString()}`;
 
 		try {
 			const response = await fetch(url, {
@@ -79,7 +78,7 @@ export class BinanceAPI {
 
 		params.signature = this.createSignature(params);
 
-		const url = `${this.apiUrl}/api/v3/order?${querystring.stringify(params)}`;
+		const url = `${this.apiUrl}/api/v3/order?${new URLSearchParams(params).toString()}`;
 
 		try {
 			const response = await fetch(url, {

--- a/src/services/telegram-api.js
+++ b/src/services/telegram-api.js
@@ -1,5 +1,4 @@
 import fetch from "node-fetch";
-import querystring from "querystring";
 
 export class TelegramAPI {
 	/**
@@ -27,7 +26,7 @@ export class TelegramAPI {
 			parse_mode: "markdown"
 		}
 
-		const url = `${this.apiUrl}/bot${this.token}/sendMessage?${querystring.stringify(params)}`;
+		const url = `${this.apiUrl}/bot${this.token}/sendMessage?${new URLSearchParams(params).toString()}`;
 
 		try {
 			const response = await fetch(url, {


### PR DESCRIPTION
The querystring API is considered Legacy. While it is still maintained, new code should use the <URLSearchParams> API instead. 
_(query-string is a package and URLSearchParams is a native interface.)_